### PR TITLE
Fix for parsing of corrected metar #12

### DIFF
--- a/metar.js
+++ b/metar.js
@@ -131,6 +131,11 @@ METAR.prototype.parseCorrection = function() {
         this.result.correction = token.substr(2,1);
         this.next();
     }
+
+    if (token.lastIndexOf('COR', 0) == 0) {
+        this.result.correction = true;
+        this.next();
+    }
 };
 
 var variableWind = /^([0-9]{3})V([0-9]{3})$/;

--- a/test/parse_metar_test.js
+++ b/test/parse_metar_test.js
@@ -25,6 +25,9 @@ describe("METAR parser", function() {
     it("can parse correction", function() {
         var m = parseMetar("CYZF 241700Z CCA 32012G18KT 12SM BKN007 OVC042 M02/M05 A2956");
         assert.equal("A", m.correction);
+
+        m = parseMetar("PAOM 302353Z COR 32005KT 10SM CLR M03/M09 A2993");
+        assert.equal(true, m.correction);
     });
 
     it("can parse metar without auto", function() {


### PR DESCRIPTION
This adds parsing of METAR corrections without a revision letter.  e.g. PAOM 302353Z COR 32005KT 10SM CLR M03/M09 A2993